### PR TITLE
Cancel-able standard proposals

### DIFF
--- a/contracts/proposal/Cancelable.sol
+++ b/contracts/proposal/Cancelable.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+
+import "../ownership/Ownable.sol";
+import "../governance/Governance.sol";
+
+contract Cancelable is Ownable {
+    constructor() public {
+        Ownable.initialize(msg.sender);
+    }
+
+    function cancel(uint256 myID, address govAddress) external onlyOwner {
+        Governance gov = Governance(govAddress);
+        gov.cancelProposal(myID);
+    }
+}

--- a/contracts/proposal/PlainTextProposal.sol
+++ b/contracts/proposal/PlainTextProposal.sol
@@ -1,11 +1,12 @@
 pragma solidity ^0.5.0;
 
 import "./BaseProposal.sol";
+import "./Cancelable.sol";
 
 /**
  * @dev PlainText proposal
  */
-contract PlainTextProposal is BaseProposal {
+contract PlainTextProposal is BaseProposal, Cancelable {
     constructor(string memory __name, string memory __description, bytes32[] memory __options,
         uint256 __minVotes, uint256 __minAgreement, uint256 __start, uint256 __minEnd, uint256 __maxEnd, address verifier) public {
         _name = __name;

--- a/contracts/proposal/SoftwareUpgradeProposal.sol
+++ b/contracts/proposal/SoftwareUpgradeProposal.sol
@@ -2,11 +2,12 @@ pragma solidity ^0.5.0;
 
 import "../upgrade/Upgradability.sol";
 import "./BaseProposal.sol";
+import "./Cancelable.sol";
 
 /**
  * @dev SoftwareUpgrade proposal
  */
-contract SoftwareUpgradeProposal is BaseProposal {
+contract SoftwareUpgradeProposal is BaseProposal, Cancelable {
     Upgradability public upgradableContract;
     address public newContractAddress;
 

--- a/contracts/proposal/SoftwareUpgradeProposal.sol
+++ b/contracts/proposal/SoftwareUpgradeProposal.sol
@@ -8,12 +8,12 @@ import "./Cancelable.sol";
  * @dev SoftwareUpgrade proposal
  */
 contract SoftwareUpgradeProposal is BaseProposal, Cancelable {
-    Upgradability public upgradableContract;
-    address public newContractAddress;
+    address public upgradableContract;
+    address public newImplementation;
 
     constructor(string memory __name, string memory __description,
         uint256 __minVotes, uint256 __minAgreement, uint256 __start, uint256 __minEnd, uint256 __maxEnd,
-        address __upgradableContract, address __newContractAddress, address verifier) public {
+        address __upgradableContract, address __newImplementation, address verifier) public {
         _name = __name;
         _description = __description;
         _options.push(bytes32("upgrade"));
@@ -23,8 +23,8 @@ contract SoftwareUpgradeProposal is BaseProposal, Cancelable {
         _start = __start;
         _minEnd = __minEnd;
         _maxEnd = __maxEnd;
-        upgradableContract = Upgradability(__upgradableContract);
-        newContractAddress = __newContractAddress;
+        upgradableContract = __upgradableContract;
+        newImplementation = __newImplementation;
         // verify the proposal right away to avoid deploying a wrong proposal
         if (verifier != address(0)) {
             require(verifyProposalParams(verifier), "failed validation");
@@ -39,10 +39,11 @@ contract SoftwareUpgradeProposal is BaseProposal, Cancelable {
         return true;
     }
 
-    event SoftwareUpgradeIsDone(address newContractAddress);
+    event SoftwareUpgradeIsDone(address newImplementation);
 
-    function execute(address, uint256) external {
-        upgradableContract.upgradeTo(newContractAddress);
-        emit SoftwareUpgradeIsDone(newContractAddress);
+    function execute(address selfAddr, uint256) external {
+        SoftwareUpgradeProposal self = SoftwareUpgradeProposal(selfAddr);
+        Upgradability(self.upgradableContract()).upgradeTo(self.newImplementation());
+        emit SoftwareUpgradeIsDone(self.newImplementation());
     }
 }


### PR DESCRIPTION
- Make standard proposals cancelable
- Refactor SoftwareUpgradeProposal, fix memory access inside `execute` function