### PR TITLE
Split "executable" proposals into "call-executable" and "delegatecall-executable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Governance contract
 
-Governance contract supports on-chain voting by Fantom token holders on arbitrary topics. Each voting topic is called called a "proposal".
+Governance contract supports on-chain voting by arbitrary members on arbitrary topics. Each voting topic is called a "proposal".
 
 The contract is designed to be universal and flexible:
 - The governance isn't coupled to any specific staking contract, but relies on an interface to get voter weights.
@@ -11,83 +11,9 @@ The contract is designed to be universal and flexible:
 - It can handle an arbitrary number of active proposals simultaneously.
 - The contract can also support an arbitrary number of active voters simultaneously.
 
-## Integration interface
+## Wiki
 
-A Governance relies on the Governable interface to get voter weights.
-
-A naive example of a governable contract may be found in UnitTestGovernable.
-
-## Submitting a proposal
-
-Any FTM token holder is allowed to submit a proposal. Each proposal submission will require a cost (called fee), which is a contract instant. Proposal fee will get burnt during the operation.
-
-## Delegations
-
-Within a governable contract, voters can get delegations from other voters.
-
-When voter makes a vote, the contract assumes that all his delegators agree with it, effectively increasing vote's weight. If a delegator doesn't agree with the opinions of a voter he delegated to, then he can override it with his own vote.
-
-## Proposal templates
-
-Each proposal is defined by its proposal contract. A proposal contract holds proposal parameters and it may define an execution logic, if the proposal is executable.
-
-Proposals are defined by contracts, and there are some constraints imposed on them.
-
-To define such proposal constraints, proposal templates are used. Each proposal template defines the following conditions:
-- Contract bytecode: If defined, then proposal's code must match to this example.
-- Executable (bool): True if proposal should get executed on approval.
-- MinVotes (ratio): Minimum voting turnout.
-- minAgreement (ratio): Minimum allowed `Minimum voting agreement`.
-- opinionScales (uint[]): Each opinion scale defines an exact measure of agreement which voter may choose.
-- minVotingDuration (seconds): Minimum duration of the voting.
-- maxVotingDuration (seconds): Maximum duration of the voting.
-- minStartDelay (seconds): Minimum delay of the voting (i.e. must start with a delay).
-- maxStartDelay (seconds): Maximum delay of the voting (i.e. must start sooner).
-
-Some examples of proposal templates:
-1. Unknown non-executable: These proposals aren't executable and are unlikely to break anything. Thus, the requirements above are not very strict.
-2. Unknown executable: Proposals of this kind are executable and their bytecode can be arbitrary. The requirements above must be specified as strict as possible.
-3. Depositing proposal: Such proposals gather funds and allow to transfer them to a specific address after proposal approval. These proposals are executable but have a verified bytecode, and thus the requirements above are moderately strict.
-
-Addition to the new templates may be done within an executable proposal.
-
-## What proposals can do
-
-If proposal is executable, then it may perform arbitrary actions on behalf of the governance contract.
-
-Some proposal templates require a specific bytecode, which may limit the freedom of possible actions.
-
-## Voting model
-
-#### Options and opinions
-
-Each proposal defines a list of options. Voter must provide a single opinion for each option during the voting for a proposal.
-
-Opinion is recorded as a number within [0, number of opinions).
-
-For example, let's consider an example proposal that has 3 options and the following opinion scales {0, 2, 3, 4, 5} to represent {strongly disagree, disagree, neutral, agree and strongly agree}.
-
-A vote {0, 2, 4} from a voter has the following meaning: `I strongly disagree (scale=0) with option 0, I'm neutral (scale=3) about option 1, I strongly agree (scale=5) with option 2`.
-
-If we also assume that voter had a weight=100.0, then he added the following agreement to a counter of each option: `0 * 100.0 / 5 = 0` for option 0, `3 * 100.0 / 5 = 60` for option 1, `5 * 100.0 / 5 = 100` for option 2.
-
-That being said, the opinion scale defines an exact measure of agreement which voter may choose.
-
-#### Voting tally
-
-Each proposal has the following parameters, which define requirements for the proposal to get approved:
-- Minimum voting turnout (min. votes)
-- Minimum voting agreement
-- Minimum voting end time
-- Maximum voting end time
-
-Minimum voting turnout is minimum ratio of `voted voters weight`/`total voters weight` to perform the voting tally.
-Maximum voting end time is the earliest possible time to perform the voting tally.
-Minimum voting agreement is the minimum value of `agreement counter`/`voted voters weight` for an option to possibly win.
-Maximum voting end time is the the latest possible time to perform the voting tally. If proposal wasn't accepted and this period has passed, then it'll get rejected during the task handling.
-
-If no option received an agreement ratio higher than `Minimum voting agreement`, then proposal gets rejected.
-Otherwise, an option with maximum agreement wins the election.
+Check out the wiki to get more details.
 
 # Test
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Compiling your contracts...
     ✓ checking proposal verification with explicit timestamps and opinions (1046ms)
     ✓ checking self-vote creation (580ms)
     ✓ checking voting tally for a self-voter (949ms)
+    ✓ checking proposal execution via call (443ms)
+    ✓ checking proposal execution via delegatecall (407ms)
+    ✓ checking proposal rejecting before max voting end is reached (413ms)
     ✓ checking voting tally with low turnout (486ms)
     ✓ checking execution expiration (419ms)
     ✓ checking proposal is discarded if low enough agreement after expiration period (401ms)
@@ -169,5 +172,5 @@ Compiling your contracts...
       ✓ cancel votes via recounting gradually in reversed order (294ms)
 
 
-  32 passing (39s)
+  35 passing (39s)
 ```

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -269,6 +269,7 @@ contract Governance is Initializable, ReentrancyGuard, GovernanceSettings, Versi
             // silence unused variable warning
             success;
             result;
+            return success;
         }
         return true;
     }

--- a/contracts/governance/Proposal.sol
+++ b/contracts/governance/Proposal.sol
@@ -9,9 +9,15 @@ library Proposal {
         uint256 votingMaxEndTime; // date of latest possible voting end
     }
 
+    enum ExecType {
+        NONE,
+        CALL,
+        DELEGATECALL
+    }
+
     struct Parameters {
         uint256 pType; // type of proposal (e.g. plaintext, software upgrade)
-        bool executable; // true if proposal should get executed on approval
+        ExecType executable; // proposal execution type when proposal gets resolved
         uint256 minVotes; // min. quorum (ratio)
         // minAgreement is the minimum acceptable ratio of agreement for an option.
         // It's guaranteed not to win otherwise.

--- a/contracts/governance/ProposalTemplates.sol
+++ b/contracts/governance/ProposalTemplates.sol
@@ -25,7 +25,7 @@ contract ProposalTemplates is Initializable, IProposalVerifier, Ownable, Version
         string name;
         address exampleAddress; // used as a code template
         bytes32 codeHash; // sha3 hash of code
-        bool executable; // true if proposal should get executed on approval
+        Proposal.ExecType executable; // proposal execution type when proposal gets resolved
         uint256 minVotes; // minimum voting turnout (ratio)
         uint256 minAgreement; // minimum allowed minAgreement
         uint256[] opinionScales; // Each opinion scale defines an exact measure of agreement which voter may choose
@@ -44,14 +44,14 @@ contract ProposalTemplates is Initializable, IProposalVerifier, Ownable, Version
     }
 
     // get returns proposal template
-    function get(uint256 pType) public view returns (string memory name, address exampleAddress, bool executable, uint256 minVotes, uint256 minAgreement, uint256[] memory opinionScales, uint256 minVotingDuration, uint256 maxVotingDuration, uint256 minStartDelay, uint256 maxStartDelay) {
+    function get(uint256 pType) public view returns (string memory name, address exampleAddress, Proposal.ExecType executable, uint256 minVotes, uint256 minAgreement, uint256[] memory opinionScales, uint256 minVotingDuration, uint256 maxVotingDuration, uint256 minStartDelay, uint256 maxStartDelay) {
         ProposalTemplate storage t = proposalTemplates[pType];
         return (t.name, t.exampleAddress, t.executable, t.minVotes, t.minAgreement, t.opinionScales, t.minVotingDuration, t.maxVotingDuration, t.minStartDelay, t.maxStartDelay);
     }
 
     // addTemplate adds a template into the library
     // template must have unique type
-    function addTemplate(uint256 pType, string calldata name, address exampleAddress, bool executable, uint256 minVotes, uint256 minAgreement, uint256[] calldata opinionScales, uint256 minVotingDuration, uint256 maxVotingDuration, uint256 minStartDelay, uint256 maxStartDelay) external onlyOwner {
+    function addTemplate(uint256 pType, string calldata name, address exampleAddress, Proposal.ExecType executable, uint256 minVotes, uint256 minAgreement, uint256[] calldata opinionScales, uint256 minVotingDuration, uint256 maxVotingDuration, uint256 minStartDelay, uint256 maxStartDelay) external onlyOwner {
         ProposalTemplate storage template = proposalTemplates[pType];
         // empty name is a marker of non-existing template
         require(bytes(name).length != 0, "empty name");
@@ -88,7 +88,7 @@ contract ProposalTemplates is Initializable, IProposalVerifier, Ownable, Version
     }
 
     // verifyProposalParams checks proposal code and parameters
-    function verifyProposalParams(uint256 pType, bool exec, uint256 minVotes, uint256 minAgreement, uint256[] calldata opinionScales, uint256 start, uint256 minEnd, uint256 maxEnd) external view returns (bool) {
+    function verifyProposalParams(uint256 pType, Proposal.ExecType executable, uint256 minVotes, uint256 minAgreement, uint256[] calldata opinionScales, uint256 start, uint256 minEnd, uint256 maxEnd) external view returns (bool) {
         if (start < block.timestamp) {
             // start in the past
             return false;
@@ -110,7 +110,7 @@ contract ProposalTemplates is Initializable, IProposalVerifier, Ownable, Version
             return false;
         }
         ProposalTemplate memory template = proposalTemplates[pType];
-        if (exec != template.executable) {
+        if (executable != template.executable) {
             // inconsistent executable flag
             return false;
         }

--- a/contracts/proposal/BaseProposal.sol
+++ b/contracts/proposal/BaseProposal.sol
@@ -33,9 +33,9 @@ contract BaseProposal is IProposal {
         return uint256(StdProposalTypes.NOT_INIT);
     }
 
-    function executable() public view returns (bool) {
+    function executable() public view returns (Proposal.ExecType) {
         require(false, "must be overridden");
-        return false;
+        return Proposal.ExecType.NONE;
     }
 
     function minVotes() public view returns (uint256) {
@@ -74,7 +74,11 @@ contract BaseProposal is IProposal {
         return _description;
     }
 
-    function execute(address, uint256) external {
-        require(false, "not executable");
+    function execute_delegatecall(address, uint256) external {
+        require(false, "not delegatecall-executable");
+    }
+
+    function execute_call(uint256) external {
+        require(false, "not call-executable");
     }
 }

--- a/contracts/proposal/IProposal.sol
+++ b/contracts/proposal/IProposal.sol
@@ -1,13 +1,15 @@
 pragma solidity ^0.5.0;
 
+import "../governance/Proposal.sol";
+
 /**
  * @dev An abstract proposal
  */
 contract IProposal {
     // Get type of proposal (e.g. plaintext, software upgrade)
     function pType() external view returns (uint256);
-    // True if proposal should get executed on approval
-    function executable() external view returns (bool);
+    // Proposal execution type when proposal gets resolved
+    function executable() external view returns (Proposal.ExecType);
     // Get min. turnout (ratio)
     function minVotes() external view returns (uint256);
     // Get min. agreement for options (ratio)
@@ -23,9 +25,13 @@ contract IProposal {
     // Get date of latest possible voting end
     function votingMaxEndTime() external view returns (uint256);
 
-    // execute proposal logic on approval (if executable)
-    // Called via delegatecall from governance contract, hence selfAddress is provided
-    function execute(address selfAddress, uint256 optionID) external;
+    // execute proposal logic on approval (if executable == call)
+    // Called via call opcode from governance contract
+    function execute_call(uint256 optionID) external;
+
+    // execute proposal logic on approval (if executable == delegatecall)
+    // Called via delegatecall opcode from governance contract, hence selfAddress is provided
+    function execute_delegatecall(address selfAddress, uint256 optionID) external;
 
     // Get human-readable name
     function name() external view returns (string memory);
@@ -36,7 +42,14 @@ contract IProposal {
     enum StdProposalTypes {
         NOT_INIT,
         UNKNOWN_NON_EXECUTABLE,
-        UNKNOWN_EXECUTABLE,
+        UNKNOWN_CALL_EXECUTABLE,
+        UNKNOWN_DELEGATECALL_EXECUTABLE,
+        GAP4,
+        GAP5,
+        GAP6,
+        GAP7,
+        GAP8,
+        GAP9,
         PLAIN_TEXT,
         SOFTWARE_UPGRADE
     }

--- a/contracts/proposal/IProposalVerifier.sol
+++ b/contracts/proposal/IProposalVerifier.sol
@@ -7,7 +7,7 @@ import "./IProposal.sol";
  */
 interface IProposalVerifier {
     // Verifies proposal parameters with respect to the stored template of same type
-    function verifyProposalParams(uint256 pType, bool exec, uint256 minVotes, uint256 minAgreement, uint256[] calldata opinionScales, uint256 start, uint256 minEnd, uint256 maxEnd) external view returns (bool);
+    function verifyProposalParams(uint256 pType, Proposal.ExecType executable, uint256 minVotes, uint256 minAgreement, uint256[] calldata opinionScales, uint256 start, uint256 minEnd, uint256 maxEnd) external view returns (bool);
 
     // Verifies proposal code of the specified type and address
     function verifyProposalCode(uint256 pType, address propAddr) external view returns (bool);

--- a/contracts/proposal/PlainTextProposal.sol
+++ b/contracts/proposal/PlainTextProposal.sol
@@ -29,8 +29,8 @@ contract PlainTextProposal is BaseProposal, Cancelable {
         return uint256(StdProposalTypes.PLAIN_TEXT);
     }
 
-    // Returns false as it is not executable
-    function executable() public view returns (bool) {
-        return false;
+    // Returns execution type
+    function executable() public view returns (Proposal.ExecType) {
+        return Proposal.ExecType.NONE;
     }
 }

--- a/contracts/proposal/SoftwareUpgradeProposal.sol
+++ b/contracts/proposal/SoftwareUpgradeProposal.sol
@@ -35,13 +35,13 @@ contract SoftwareUpgradeProposal is BaseProposal, Cancelable {
         return uint256(StdProposalTypes.SOFTWARE_UPGRADE);
     }
 
-    function executable() public view returns (bool) {
-        return true;
+    function executable() public view returns (Proposal.ExecType) {
+        return Proposal.ExecType.DELEGATECALL;
     }
 
     event SoftwareUpgradeIsDone(address newImplementation);
 
-    function execute(address selfAddr, uint256) external {
+    function execute_delegatecall(address selfAddr, uint256) external {
         SoftwareUpgradeProposal self = SoftwareUpgradeProposal(selfAddr);
         Upgradability(self.upgradableContract()).upgradeTo(self.newImplementation());
         emit SoftwareUpgradeIsDone(self.newImplementation());

--- a/contracts/test/ExecLoggingProposal.sol
+++ b/contracts/test/ExecLoggingProposal.sol
@@ -2,8 +2,11 @@ pragma solidity ^0.5.0;
 
 import "../proposal/PlainTextProposal.sol";
 import "../governance/Governance.sol";
+import "../governance/Proposal.sol";
 
 contract ExecLoggingProposal is PlainTextProposal {
+    Proposal.ExecType _exec;
+
     constructor(string memory v1, string memory v2, bytes32[] memory v3,
         uint256 v4, uint256 v5, uint256 v6, uint256 v7, uint256 v8, address v9) PlainTextProposal(v1, v2, v3, v4, v5, v6, v7, v8, v9) public {}
 
@@ -12,11 +15,15 @@ contract ExecLoggingProposal is PlainTextProposal {
     }
 
     function pType() public view returns (uint256) {
-        return uint256(StdProposalTypes.UNKNOWN_EXECUTABLE);
+        return 15;
     }
 
-    function executable() public view returns (bool) {
-        return true;
+    function executable() public view returns (Proposal.ExecType) {
+        return _exec;
+    }
+
+    function setExecutable(Proposal.ExecType __exec) public {
+        _exec = __exec;
     }
 
     function cancel(uint256 myID, address govAddress) public {
@@ -36,8 +43,12 @@ contract ExecLoggingProposal is PlainTextProposal {
         executedOption = optionID;
     }
 
-    function execute(address selfAddr, uint256 optionID) external {
+    function execute_delegatecall(address selfAddr, uint256 optionID) external {
         ExecLoggingProposal self = ExecLoggingProposal(selfAddr);
         self.executeNonDelegateCall(address(this), msg.sender, optionID);
+    }
+
+    function execute_call(uint256 optionID) external {
+        executeNonDelegateCall(address(this), msg.sender, optionID);
     }
 }

--- a/contracts/test/ExplicitProposal.sol
+++ b/contracts/test/ExplicitProposal.sol
@@ -6,7 +6,7 @@ contract ExplicitProposal is BaseProposal {
     using SafeMath for uint256;
 
     uint256 _pType;
-    bool _executable;
+    Proposal.ExecType _exec;
 
     function setType(uint256 v) public {
         _pType = v;
@@ -36,8 +36,8 @@ contract ExplicitProposal is BaseProposal {
         _maxEnd = v;
     }
 
-    function setExecutable(bool v) public {
-        _executable = v;
+    function setExecutable(Proposal.ExecType v) public {
+        _exec = v;
     }
 
     function setOptions(bytes32[] memory v) public {
@@ -56,8 +56,8 @@ contract ExplicitProposal is BaseProposal {
         return _pType;
     }
 
-    function executable() public view returns (bool) {
-        return _executable;
+    function executable() public view returns (Proposal.ExecType) {
+        return _exec;
     }
 
     function votingStartTime() public view returns (uint256) {
@@ -72,5 +72,6 @@ contract ExplicitProposal is BaseProposal {
         return _maxEnd;
     }
 
-    function execute(address, uint256) external {}
+    function execute_delegatecall(address, uint256) external {}
+    function execute_call(uint256) external {}
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -90,7 +90,7 @@ module.exports = {
       settings: {          // See the solidity docs for advice about optimization and evmVersion
         optimizer: {
           enabled: true,
-          runs: 1
+          runs: 5000
         },
       //  evmVersion: "byzantium"
       }


### PR DESCRIPTION
- add call-executable proposals for cases when `call` is enough for proposal's task
- add tests for call-executable and delegate-executable proposals
- add test for proposal rejecting before max voting end is reached