### PR TITLE
Update version contract

### DIFF
--- a/contracts/version/Version.sol
+++ b/contracts/version/Version.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-/// @dev The version info of this contract
+/// @notice The version info of the Governance contract
 contract Version {
-    // @dev Returns the version of this contract.
+    // @notice Returns the version.
     function version() public pure returns (bytes4) {
-        // version 00.0.2
-        return "0002";
+        return 0x00000002; // version 0.0.0.2
     }
 }

--- a/contracts/version/Version.sol
+++ b/contracts/version/Version.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.27;
 /// @notice The version info of the Governance contract
 contract Version {
     // @notice Returns the version.
-    function version() public pure returns (bytes4) {
-        return 0x00000002; // version 0.0.0.2
+    function version() public pure returns (bytes3) {
+        return 0x000002; // version 0.0.2
     }
 }


### PR DESCRIPTION
This PR corrects the `version()` func in `Version` contract. String `0002` would be encoded into `0x30303032` which is 4 bytes, but we would not be able to encode version 0.0.0.10 into 4 bytes. 
This will allow us to encode versions up to 255.

It also updates the documentation