### PR TITLE
Use solhint

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,0 +1,8 @@
+{
+  "extends": "solhint:recommended",
+  "rules": {
+    "func-visibility": ["warn", {"ignoreConstructors": true}],
+    "max-states-count": ["off"],
+    "no-inline-assembly": "off"
+  }
+}

--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.soliumignore
+++ b/.soliumignore
@@ -1,2 +1,0 @@
-node_modules
-contracts/Flattened.sol

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,7 +1,0 @@
-{
-   "extends": "solium:all",
-   "rules": {
-    	   "uppercase": "off"
-   }
-}
-

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,7 @@ checksum:
 .PHONY: test
 test:
 	npx hardhat test --typecheck
+
+.PHONY: lint
+lint:
+	 solhint 'contracts/**/*.sol'

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -225,7 +225,7 @@ contract Governance is Initializable, ReentrancyGuardTransient, GovernanceSettin
 
         ProposalState storage prop = _proposals[proposalID];
 
-        require(prop.params.proposalContract != address(0), "proposal with a given ID doesnt exist");
+        require(prop.params.proposalContract != address(0), "given proposalID doesn't exist");
         require(prop.status == ProposalStatus.INITIAL, "proposal isn't active");
         require(block.timestamp >= prop.params.deadlines.votingStartTime, "proposal voting hasn't begun");
         require(_votes[msg.sender][delegatedTo][proposalID].weight == 0, "vote already exists");
@@ -238,7 +238,7 @@ contract Governance is Initializable, ReentrancyGuardTransient, GovernanceSettin
     /// @notice Create a new proposal.
     /// @param proposalContract The address of the proposal contract.
     function createProposal(address proposalContract) external nonReentrant payable {
-        require(msg.value == proposalFee(), "paid proposal fee is wrong");
+        require(msg.value == proposalFee, "paid proposal fee is wrong");
 
         lastProposalID++;
         _createProposal(lastProposalID, proposalContract);
@@ -267,7 +267,7 @@ contract Governance is Initializable, ReentrancyGuardTransient, GovernanceSettin
         uint256 votingMaxEndTime = p.votingMaxEndTime();
         bytes32[] memory options = p.options();
         // check the parameters and contract
-        require(options.length != 0, "proposal options are empty - nothing to vote for");
+        require(options.length != 0, "proposal options are empty");
         require(options.length <= maxOptions, "too many options");
         bool ok;
         ok = proposalVerifier.verifyProposalParams(
@@ -301,7 +301,7 @@ contract Governance is Initializable, ReentrancyGuardTransient, GovernanceSettin
     /// @param proposalID The ID of the proposal.
     function cancelProposal(uint256 proposalID) external nonReentrant {
         ProposalState storage prop = _proposals[proposalID];
-        require(prop.params.proposalContract != address(0), "proposal with a given ID doesnt exist");
+        require(prop.params.proposalContract != address(0), "given proposalID doesn't exist");
         require(prop.status == ProposalStatus.INITIAL, "proposal isn't active");
         require(prop.votes == 0, "voting has already begun");
         require(msg.sender == prop.params.proposalContract, "sender not the proposal address");

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -419,6 +419,7 @@ contract Governance is Initializable, ReentrancyGuardTransient, GovernanceSettin
     /// @dev Execute a proposal.
     /// @param prop The state of the proposal.
     /// @param winnerOptionID The ID of the winning option.
+    /// @return success Whether the execution was successful.
     /// @return expired Whether the execution period has expired.
     function executeProposal(ProposalState storage prop, uint256 winnerOptionID) internal returns (bool, bool) {
         bool executable = prop.params.executable == Proposal.ExecType.CALL || prop.params.executable == Proposal.ExecType.DELEGATECALL;

--- a/contracts/governance/GovernanceSettings.sol
+++ b/contracts/governance/GovernanceSettings.sol
@@ -17,7 +17,7 @@ contract GovernanceSettings is Ownable {
     uint256 public taskErasingReward;
     /// @notice maxOptions is the maximum number of options that can be offered in a single proposal
     uint256 public maxOptions;
-    /// @notice maxExecutionPeriod is the period after the end of voting during which the proposal can be executed 
+    /// @notice maxExecutionPeriod is the period after the end of voting during which the proposal can be executed
     uint256 public maxExecutionPeriod;
 
     // reverted when proposal fee would be under the sum of burnt fee and rewards

--- a/contracts/governance/Proposal.sol
+++ b/contracts/governance/Proposal.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import {IProposal} from "../proposal/base/IProposal.sol";
-
 /// @notice Proposal is a library for handling information about proposal
 library Proposal {
     struct Timeline {

--- a/contracts/governance/StatusConstants.sol
+++ b/contracts/governance/StatusConstants.sol
@@ -15,6 +15,7 @@ contract StatusConstants {
     uint256 constant public STATUS_FAILED = 1 << 1;
     uint256 constant public STATUS_CANCELED = 1 << 2;
     uint256 constant public STATUS_EXECUTION_EXPIRED = 1 << 3;
+    uint256 constant public TASK_VOTING = 1;
 
     function statusInitial() internal pure returns (uint256) {
         return STATUS_INITIAL;
@@ -39,7 +40,4 @@ contract StatusConstants {
     function isInitialStatus(uint256 status) internal pure returns (bool) {
         return status == STATUS_INITIAL;
     }
-
-    // task assignments
-    uint256 constant TASK_VOTING = 1;
 }

--- a/contracts/governance/StatusConstants.sol
+++ b/contracts/governance/StatusConstants.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+/// @notice StatusConstants.sol defines status of governance proposals.
+contract StatusConstants {
+    enum Status {
+        INITIAL,
+        RESOLVED,
+        FAILED
+    }
+
+    // bit map
+    uint256 constant public STATUS_INITIAL = 0;
+    uint256 constant public STATUS_RESOLVED = 1;
+    uint256 constant public STATUS_FAILED = 1 << 1;
+    uint256 constant public STATUS_CANCELED = 1 << 2;
+    uint256 constant public STATUS_EXECUTION_EXPIRED = 1 << 3;
+
+    function statusInitial() internal pure returns (uint256) {
+        return STATUS_INITIAL;
+    }
+
+    function statusExecutionExpired() internal pure returns (uint256) {
+        return STATUS_EXECUTION_EXPIRED;
+    }
+
+    function statusFailed() internal pure returns (uint256) {
+        return STATUS_FAILED;
+    }
+
+    function statusCanceled() internal pure returns (uint256) {
+        return STATUS_CANCELED;
+    }
+
+    function statusResolved() internal pure returns (uint256) {
+        return STATUS_RESOLVED;
+    }
+
+    function isInitialStatus(uint256 status) internal pure returns (bool) {
+        return status == STATUS_INITIAL;
+    }
+
+    // task assignments
+    uint256 constant TASK_VOTING = 1;
+}

--- a/contracts/interfaces/IProposal.sol
+++ b/contracts/interfaces/IProposal.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import {Proposal} from "../../governance/Proposal.sol";
+import {Proposal} from "../governance/Proposal.sol";
 
 /// @notice The proposal interface
 interface IProposal {

--- a/contracts/pfactory/PlainTextProposalFactory.sol
+++ b/contracts/pfactory/PlainTextProposalFactory.sol
@@ -30,7 +30,7 @@ contract PlainTextProposalFactory is ScopedVerifier {
         uint256 __start,
         uint256 __minEnd,
         uint256 __maxEnd
-    ) payable external {
+    ) external payable {
         // use memory to avoid stack overflow
         uint256[] memory params = new uint256[](5);
         params[0] = __minVotes;

--- a/contracts/pfactory/SlashingRefundProposalFactory.sol
+++ b/contracts/pfactory/SlashingRefundProposalFactory.sol
@@ -24,7 +24,7 @@ contract SlashingRefundProposalFactory is ScopedVerifier {
     /// @param __minEnd The minimum end time
     /// @param __maxEnd The maximum end time
     function create(uint256 __validatorID, string calldata __description,
-        uint256 __minVotes, uint256 __minAgreement, uint256 __start, uint256 __minEnd, uint256 __maxEnd) payable external {
+        uint256 __minVotes, uint256 __minAgreement, uint256 __start, uint256 __minEnd, uint256 __maxEnd) external payable {
         // use memory to avoid stack overflow
         uint256[] memory params = new uint256[](5);
         params[0] = __minVotes;

--- a/contracts/proposal/NetworkParameterProposal.sol
+++ b/contracts/proposal/NetworkParameterProposal.sol
@@ -40,7 +40,7 @@ interface ConstsI {
 
 /// @notice A proposal to update network parameters
 contract NetworkParameterProposal is DelegatecallExecutableProposal, Cancelable {
-    Proposal.ExecType _exec;
+    Proposal.ExecType public _exec;
     ConstsI public consts;
     uint8 public methodID;
     uint256[] public getOptionVal;

--- a/contracts/proposal/NetworkParameterProposal.sol
+++ b/contracts/proposal/NetworkParameterProposal.sol
@@ -40,7 +40,7 @@ interface ConstsI {
 
 /// @notice A proposal to update network parameters
 contract NetworkParameterProposal is DelegatecallExecutableProposal, Cancelable {
-    Proposal.ExecType public _exec;
+    Proposal.ExecType internal _exec;
     ConstsI public consts;
     uint8 public methodID;
     uint256[] public getOptionVal;

--- a/contracts/proposal/NetworkParameterProposal.sol
+++ b/contracts/proposal/NetworkParameterProposal.sol
@@ -130,7 +130,7 @@ contract NetworkParameterProposal is DelegatecallExecutableProposal, Cancelable 
     /// @dev Depending on the methodID, the corresponding network parameter will be updated
     /// @param selfAddr The address of the proposal
     /// @param winnerOptionID The winning option ID
-    function execute_delegatecall(address selfAddr, uint256 winnerOptionID) external override {
+    function executeDelegateCall(address selfAddr, uint256 winnerOptionID) external override {
         NetworkParameterProposal self = NetworkParameterProposal(selfAddr);
         uint256 __methodID = self.methodID();
 
@@ -170,7 +170,7 @@ contract NetworkParameterProposal is DelegatecallExecutableProposal, Cancelable 
     }
 
     function decimalsNum(uint256 num) internal pure returns (uint256) {
-        uint decimals;
+        uint256 decimals;
         while (num != 0) {
             decimals++;
             num /= 10;

--- a/contracts/proposal/SlashingRefundProposal.sol
+++ b/contracts/proposal/SlashingRefundProposal.sol
@@ -40,14 +40,14 @@ contract SlashingRefundProposal is DelegatecallExecutableProposal, Cancelable {
         return 5003;
     }
 
-    function execute_delegatecall(address selfAddr, uint256 optionID) external override {
+    function executeDelegateCall(address selfAddr, uint256 optionID) external override {
         SlashingRefundProposal self = SlashingRefundProposal(selfAddr);
         uint256 penaltyRatio = 1e18 * optionID * 20 / 100;
         ISFC(self.sfc()).updateSlashingRefundRatio(self.validatorID(), penaltyRatio);
     }
 
     function decimalsNum(uint256 num) internal pure returns (uint256) {
-        uint decimals;
+        uint256 decimals;
         while (num != 0) {
             decimals++;
             num /= 10;

--- a/contracts/proposal/SoftwareUpgradeProposal.sol
+++ b/contracts/proposal/SoftwareUpgradeProposal.sol
@@ -34,7 +34,7 @@ contract SoftwareUpgradeProposal is DelegatecallExecutableProposal, Cancelable {
         }
     }
 
-    function execute_delegatecall(address selfAddr, uint256) external override {
+    function executeDelegateCall(address selfAddr, uint256) external override {
         SoftwareUpgradeProposal self = SoftwareUpgradeProposal(selfAddr);
         Upgradability(self.upgradeableContract()).upgradeTo(self.newImplementation());
     }

--- a/contracts/proposal/base/BaseProposal.sol
+++ b/contracts/proposal/base/BaseProposal.sol
@@ -7,20 +7,20 @@ import {Proposal} from "../../governance/Proposal.sol";
 
 /// @notice A base for any proposal
 contract BaseProposal is IProposal {
-    string public _name;
-    string public _description;
-    bytes32[]public  _options;
+    string internal _name;
+    string internal _description;
+    bytes32[]internal  _options;
 
-    uint256 public _minVotes;
-    uint256 public _minAgreement;
+    uint256 internal _minVotes;
+    uint256 internal _minAgreement;
     // Static scale for front end
     // i.e. [1, 2, 3, 4] will result in the scale being divided into 4 parts
     // where 1 means the least agreement and 4 means the most
-    uint256[] public _opinionScales;
+    uint256[] internal _opinionScales;
 
-    uint256 public _start; // Start of the voting
-    uint256 public _minEnd; // Minimal end time of the voting
-    uint256 public _maxEnd; // Maxinal end time of the voting
+    uint256 internal _start; // Start of the voting
+    uint256 internal _minEnd; // Minimal end time of the voting
+    uint256 internal _maxEnd; // Maximal end time of the voting
 
     /// @notice Verify the parameters of the proposal using a given verifier.
     /// @param verifier The address of the verifier contract.

--- a/contracts/proposal/base/BaseProposal.sol
+++ b/contracts/proposal/base/BaseProposal.sol
@@ -9,7 +9,7 @@ import {Proposal} from "../../governance/Proposal.sol";
 contract BaseProposal is IProposal {
     string internal _name;
     string internal _description;
-    bytes32[]internal  _options;
+    bytes32[] internal  _options;
 
     uint256 internal _minVotes;
     uint256 internal _minAgreement;

--- a/contracts/proposal/base/BaseProposal.sol
+++ b/contracts/proposal/base/BaseProposal.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import {IProposal} from "./IProposal.sol";
+import {IProposal} from "../../interfaces/IProposal.sol";
 import {IProposalVerifier} from "../../verifiers/IProposalVerifier.sol";
 import {Proposal} from "../../governance/Proposal.sol";
 

--- a/contracts/proposal/base/BaseProposal.sol
+++ b/contracts/proposal/base/BaseProposal.sol
@@ -7,20 +7,20 @@ import {Proposal} from "../../governance/Proposal.sol";
 
 /// @notice A base for any proposal
 contract BaseProposal is IProposal {
-    string _name;
-    string _description;
-    bytes32[] _options;
+    string public _name;
+    string public _description;
+    bytes32[]public  _options;
 
-    uint256 _minVotes;
-    uint256 _minAgreement;
+    uint256 public _minVotes;
+    uint256 public _minAgreement;
     // Static scale for front end
     // i.e. [1, 2, 3, 4] will result in the scale being divided into 4 parts
     // where 1 means the least agreement and 4 means the most
-    uint256[] _opinionScales;
+    uint256[] public _opinionScales;
 
-    uint256 _start; // Start of the voting
-    uint256 _minEnd; // Minimal end time of the voting
-    uint256 _maxEnd; // Maxinal end time of the voting
+    uint256 public _start; // Start of the voting
+    uint256 public _minEnd; // Minimal end time of the voting
+    uint256 public _maxEnd; // Maxinal end time of the voting
 
     /// @notice Verify the parameters of the proposal using a given verifier.
     /// @param verifier The address of the verifier contract.
@@ -76,11 +76,11 @@ contract BaseProposal is IProposal {
         return _description;
     }
 
-    function execute_delegatecall(address, uint256) external virtual {
+    function executeDelegateCall(address, uint256) external virtual {
         require(false, "not delegatecall-executable");
     }
 
-    function execute_call(uint256) external virtual {
+    function executeCall(uint256) external virtual {
         require(false, "not call-executable");
     }
 }

--- a/contracts/proposal/base/CallExecutableProposal.sol
+++ b/contracts/proposal/base/CallExecutableProposal.sol
@@ -15,7 +15,7 @@ contract CallExecutableProposal is BaseProposal {
         return uint256(StdProposalTypes.UNKNOWN_CALL_EXECUTABLE);
     }
 
-    function execute_call(uint256) external override virtual {
+    function executeCall(uint256) external override virtual {
         require(false, "must be overridden");
     }
 }

--- a/contracts/proposal/base/DelegatecallExecutableProposal.sol
+++ b/contracts/proposal/base/DelegatecallExecutableProposal.sol
@@ -14,7 +14,7 @@ contract DelegatecallExecutableProposal is BaseProposal {
         return uint256(StdProposalTypes.UNKNOWN_DELEGATECALL_EXECUTABLE);
     }
 
-    function execute_delegatecall(address, uint256) external override virtual{
+    function executeDelegateCall(address, uint256) external override virtual{
         require(false, "must be overridden");
     }
 }

--- a/contracts/proposal/base/IProposal.sol
+++ b/contracts/proposal/base/IProposal.sol
@@ -46,13 +46,13 @@ interface IProposal {
     /// @dev execute proposal logic on approval (if executable == call)
     /// @dev Called via call opcode from governance contract
     /// @param optionID The index of the option to execute
-    function execute_call(uint256 optionID) external;
+    function executeCall(uint256 optionID) external;
 
     /// @dev execute proposal logic on approval (if executable == delegatecall)
     /// @dev Called via delegatecall opcode from governance contract, hence selfAddress is provided
     /// @param selfAddress The address of the proposal contract
     /// @param optionID The index of the option to execute
-    function execute_delegatecall(address selfAddress, uint256 optionID) external;
+    function executeDelegateCall(address selfAddress, uint256 optionID) external;
 
     /// @dev Get human-readable name
     /// @return Human-readable name

--- a/contracts/proposal/test/ExecLoggingProposal.sol
+++ b/contracts/proposal/test/ExecLoggingProposal.sol
@@ -8,7 +8,7 @@ import {Proposal} from "../../governance/Proposal.sol";
 /// @dev A proposal that can be stores data about NonDelegateCall
 /// @dev Used for testing purposes
 contract ExecLoggingProposal is PlainTextProposal {
-    Proposal.ExecType _exec;
+    Proposal.ExecType public _exec;
 
     constructor(string memory v1, string memory v2, bytes32[] memory v3,
         uint256 v4, uint256 v5, uint256 v6, uint256 v7, uint256 v8, address v9) PlainTextProposal(v1, v2, v3, v4, v5, v6, v7, v8, v9) {}
@@ -46,12 +46,12 @@ contract ExecLoggingProposal is PlainTextProposal {
         executedOption = optionID;
     }
 
-    function execute_delegatecall(address selfAddr, uint256 optionID) external override {
+    function executeDelegateCall(address selfAddr, uint256 optionID) external override {
         ExecLoggingProposal self = ExecLoggingProposal(selfAddr);
         self.executeNonDelegateCall(address(this), msg.sender, optionID);
     }
 
-    function execute_call(uint256 optionID) external override {
+    function executeCall(uint256 optionID) external override {
         executeNonDelegateCall(address(this), msg.sender, optionID);
     }
 }

--- a/contracts/proposal/test/ExecLoggingProposal.sol
+++ b/contracts/proposal/test/ExecLoggingProposal.sol
@@ -8,7 +8,7 @@ import {Proposal} from "../../governance/Proposal.sol";
 /// @dev A proposal that can be stores data about NonDelegateCall
 /// @dev Used for testing purposes
 contract ExecLoggingProposal is PlainTextProposal {
-    Proposal.ExecType public _exec;
+    Proposal.ExecType internal _exec;
 
     constructor(string memory v1, string memory v2, bytes32[] memory v3,
         uint256 v4, uint256 v5, uint256 v6, uint256 v7, uint256 v8, address v9) PlainTextProposal(v1, v2, v3, v4, v5, v6, v7, v8, v9) {}

--- a/contracts/proposal/test/ExplicitProposal.sol
+++ b/contracts/proposal/test/ExplicitProposal.sol
@@ -7,8 +7,8 @@ import {Proposal} from "../../governance/Proposal.sol";
 /// @dev A proposal with all parameters explicitly set
 /// @dev Used for testing purposes
 contract ExplicitProposal is BaseProposal {
-    uint256 public _pType;
-    Proposal.ExecType public _exec;
+    uint256 internal _pType;
+    Proposal.ExecType internal _exec;
 
     function setType(uint256 v) public {
         _pType = v;

--- a/contracts/proposal/test/ExplicitProposal.sol
+++ b/contracts/proposal/test/ExplicitProposal.sol
@@ -7,8 +7,8 @@ import {Proposal} from "../../governance/Proposal.sol";
 /// @dev A proposal with all parameters explicitly set
 /// @dev Used for testing purposes
 contract ExplicitProposal is BaseProposal {
-    uint256 _pType;
-    Proposal.ExecType _exec;
+    uint256 public _pType;
+    Proposal.ExecType public _exec;
 
     function setType(uint256 v) public {
         _pType = v;
@@ -74,6 +74,6 @@ contract ExplicitProposal is BaseProposal {
         return _maxEnd;
     }
 
-    function execute_delegatecall(address, uint256) external override {}
-    function execute_call(uint256) external override {}
+    function executeDelegateCall(address, uint256) external override {}
+    function executeCall(uint256) external override {}
 }

--- a/contracts/test/FakeVoteRecounter.sol
+++ b/contracts/test/FakeVoteRecounter.sol
@@ -19,7 +19,7 @@ contract FakeVoteRecounter {
     function recountVote(address voterAddr, address delegatedTo, uint256 proposalID) external {
         for (uint256 i = 0; i < outdatedProposals.length; i++) {
             if (proposalID == outdatedProposals[i]) {
-                revert();
+                revert("outdated proposal");
             }
         }
         if (voterAddr != expectVoterAddr || delegatedTo != expectDelegatedTo) {

--- a/contracts/verifiers/OwnableVerifier.sol
+++ b/contracts/verifiers/OwnableVerifier.sol
@@ -15,7 +15,7 @@ contract OwnableVerifier is ScopedVerifier, Ownable {
 
     /// @notice create a new proposal
     /// @param propAddr The address of the proposal
-    function createProposal(address propAddr) payable external onlyOwner {
+    function createProposal(address propAddr) external payable onlyOwner {
         unlockedFor = propAddr;
         gov.createProposal{value: msg.value}(propAddr);
         unlockedFor = address(0);

--- a/contracts/verifiers/ProposalTemplates.sol
+++ b/contracts/verifiers/ProposalTemplates.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.27;
 
 import {Decimal} from "../common/Decimal.sol";
-import {IProposal} from "../proposal/base/IProposal.sol";
 import {IProposalVerifier} from "./IProposalVerifier.sol";
 import {Version} from "../version/Version.sol";
 import {Proposal} from "../governance/Proposal.sol";
@@ -34,7 +33,7 @@ contract ProposalTemplates is IProposalVerifier, OwnableUpgradeable, Version {
     }
 
     // templates library
-    mapping(uint256 => ProposalTemplate) proposalTemplates; // proposal type => ProposalTemplate
+    mapping(uint256 => ProposalTemplate) public proposalTemplates; // proposal type => ProposalTemplate
 
     function initialize(address _owner) public initializer {
         __Ownable_init(_owner);

--- a/contracts/verifiers/ScopedVerifier.sol
+++ b/contracts/verifiers/ScopedVerifier.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.27;
 
 import {IProposalVerifier} from "./IProposalVerifier.sol";
-import {Governance} from "../governance/Governance.sol";
 import {Proposal} from "../governance/Proposal.sol";
 
 contract ScopedVerifier is IProposalVerifier {

--- a/contracts/votesbook/VotesBookKeeper.sol
+++ b/contracts/votesbook/VotesBookKeeper.sol
@@ -16,10 +16,10 @@ contract VotesBookKeeper is OwnableUpgradeable {
 
     uint256 public maxProposalsPerVoter; // Maximum number of proposals a voter can vote on
 
-    mapping(address => mapping(address => uint256[])) votesList; // voter => delegatedTo => []proposal IDs
+    mapping(address => mapping(address => uint256[])) public votesList; // voter => delegatedTo => []proposal IDs
 
     // voter => delegatedTo => proposal ID => {index in the list + 1}
-    mapping(address => mapping(address => mapping(uint256 => uint256))) votesIndex;
+    mapping(address => mapping(address => mapping(uint256 => uint256))) public votesIndex;
 
     /// @notice Initialize the contract
     /// @param _owner The owner of the contract
@@ -126,7 +126,7 @@ contract VotesBookKeeper is OwnableUpgradeable {
 
     /// @notice Set the maximum number of proposals a voter can vote on
     /// @param v The new maximum number of proposals
-    function setMaxProposalsPerVoter(uint256 v) onlyOwner external {
+    function setMaxProposalsPerVoter(uint256 v) external onlyOwner {
         maxProposalsPerVoter = v;
     }
 }

--- a/test/Governance.ts
+++ b/test/Governance.ts
@@ -1149,15 +1149,15 @@ describe("Governance test", function () {
         const option = ethers.encodeBytes32String("opt");
         const proposal = await ethers.deployContract("PlainTextProposal", ["paintext", "plaintext-descr", [option], ethers.parseEther("0.5"), ethers.parseEther("0.8"), 30, 121, 1199, this.verifierAddress]);
 
-        await expect(this.gov.connect(this.otherAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal contract failed verification");
-        await expect(this.gov.connect(this.defaultAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal contract failed verification");
+        await expect(this.gov.connect(this.otherAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("contract failed verification");
+        await expect(this.gov.connect(this.defaultAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("contract failed verification");
         await expect(ownableVerifier.connect(this.otherAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWithCustomError(
             ownableVerifier,
             'OwnableUnauthorizedAccount',
         );
         await ownableVerifier.connect(this.defaultAcc).createProposal(proposal.getAddress(), {value: this.proposalFee});
-        await expect(this.gov.connect(this.otherAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal contract failed verification");
-        await expect(this.gov.connect(this.defaultAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal contract failed verification");
+        await expect(this.gov.connect(this.otherAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("contract failed verification");
+        await expect(this.gov.connect(this.defaultAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("contract failed verification");
         await expect(ownableVerifier.connect(this.otherAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWithCustomError(
             ownableVerifier,
             'OwnableUnauthorizedAccount',
@@ -1166,8 +1166,8 @@ describe("Governance test", function () {
         // Transfer ownership to otherAcc
         await ownableVerifier.connect(this.defaultAcc).transferOwnership(this.otherAcc);
 
-        await expect(this.gov.connect(this.defaultAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal contract failed verification");
-        await expect(this.gov.connect(this.otherAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal contract failed verification");
+        await expect(this.gov.connect(this.defaultAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("contract failed verification");
+        await expect(this.gov.connect(this.otherAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWith("contract failed verification");
         await expect(ownableVerifier.connect(this.defaultAcc).createProposal(proposal.getAddress(), {value: this.proposalFee})).to.be.revertedWithCustomError(
             ownableVerifier,
             'OwnableUnauthorizedAccount',

--- a/test/Governance.ts
+++ b/test/Governance.ts
@@ -85,9 +85,9 @@ describe("Governance test", function () {
         const manyOptions = await ethers.deployContract("PlainTextProposal", ["plaintext","plaintext-descr", [option, option, option, option, option, option, option, option, option, option], ethers.parseEther("0.5"), ethers.parseEther("0.6"), 30, 121, 1199, this.verifierAddress]);
         const oneOption = await ethers.deployContract("PlainTextProposal", ["plaintext","plaintext-descr", [option], ethers.parseEther("0.51"), ethers.parseEther("0.6"), 30, 122, 1198, this.verifierAddress]);
 
-        await expect(this.gov.createProposal(emptyOptions.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal options are empty - nothing to vote for");
+        await expect(this.gov.createProposal(emptyOptions.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal options are empty");
         await expect(this.gov.createProposal(tooManyOptions.getAddress(), {value: this.proposalFee})).to.be.revertedWith("too many options");
-        await expect(this.gov.createProposal(wrongVotes.getAddress(), {value: this.proposalFee})).to.be.revertedWith("proposal parameters failed verification");
+        await expect(this.gov.createProposal(wrongVotes.getAddress(), {value: this.proposalFee})).to.be.revertedWith("parameters failed verification");
         await expect(this.gov.createProposal(manyOptions.getAddress())).to.be.revertedWith("paid proposal fee is wrong");
         await expect(this.gov.createProposal(manyOptions.getAddress(), {value: this.proposalFee+1n})).to.be.revertedWith("paid proposal fee is wrong");
         await this.gov.createProposal(manyOptions.getAddress(), {value: this.proposalFee});
@@ -236,7 +236,7 @@ describe("Governance test", function () {
         await expect(this.gov.vote(this.defaultAcc, proposalID, choices)).to.be.revertedWith("zero weight");
         await this.sfc.stake(this.defaultAcc, ethers.parseEther("10.0"));
         // Non-existent proposal
-        await expect(this.gov.vote(this.defaultAcc, proposalID+1n, choices)).to.be.revertedWith("proposal with a given ID doesnt exist");
+        await expect(this.gov.vote(this.defaultAcc, proposalID+1n, choices)).to.be.revertedWith("given proposalID doesn't exist");
         // Incorrect choices
         await expect(this.gov.vote(this.defaultAcc, proposalID, [3n, 4n])).to.be.revertedWith("wrong number of choices");
         // Non-existent opinion
@@ -634,10 +634,10 @@ describe("Governance test", function () {
         await this.gov.vote(this.defaultAcc, proposalID, choices);
 
         // try to cancel proposal
-        await expect(this.gov.cancelProposal(proposalID+1n)).to.be.revertedWith("proposal with a given ID doesnt exist");
+        await expect(this.gov.cancelProposal(proposalID+1n)).to.be.revertedWith("given proposalID doesn't exist");
         await expect(this.gov.cancelProposal(proposalID)).to.be.revertedWith("voting has already begun");
         await this.gov.cancelVote(this.defaultAcc, proposalID);
-        await expect(this.gov.cancelProposal(proposalID)).to.be.revertedWith("must be sent from the proposal contract");
+        await expect(this.gov.cancelProposal(proposalID)).to.be.revertedWith("sender not the proposal address");
         await proposalContract.cancel(proposalID, this.gov.getAddress());
         await expect(this.gov.cancelProposal(proposalID)).to.be.revertedWith("proposal isn't active");
         await expect(this.gov.vote(this.defaultAcc, proposalID, choices)).to.be.revertedWith("proposal isn't active");
@@ -764,7 +764,7 @@ describe("Governance test", function () {
         await expect(this.gov.connect(this.delegatorAcc).vote(this.delegatorAcc, proposalID, choices1)).to.be.revertedWith("zero weight");
         await expect(this.gov.connect(this.delegatorAcc).vote(this.otherAcc, proposalID, choices1)).to.be.revertedWith("zero weight");
         await expect(this.gov.connect(this.firstVoterAcc).vote(this.delegatorAcc, proposalID, choices1)).to.be.revertedWith("zero weight");
-        await expect(this.gov.vote(this.firstVoterAcc, proposalID + 1n, choices1), "proposal with a given ID doesnt exist");
+        await expect(this.gov.vote(this.firstVoterAcc, proposalID + 1n, choices1), "given proposalID doesn't exist");
         await expect(this.gov.connect(this.delegatorAcc).vote(this.firstVoterAcc, proposalID, [3n, 4n]), "wrong number of choices");
         await expect(this.gov.connect(this.delegatorAcc).vote(this.firstVoterAcc, proposalID, [3n, 4n, 5n]), "wrong opinion ID");
         await this.gov.connect(this.delegatorAcc).vote(this.firstVoterAcc, proposalID, choices1);


### PR DESCRIPTION
This PR adds `solhint` as the linter and removes `solium`.
This PR also adds some changes reported by the linter
1) Error messages were shorten under 32 chars
2) Unused imports were removed
3) Visibility function modifiers were put to first place in the list of modifiers
4) All states were explicitly marked with visibility
5) Snake_case was removed from contracts

The linter still reports 
1) `warning  GC: Use Custom Errors instead of require statements`
2) `warning  Avoid to use low level calls`

These will be resolved in separate PRs.