### PR TITLE
Move governable interaface

### DIFF
--- a/contracts/adapters/SFCGovernableAdapter.sol
+++ b/contracts/adapters/SFCGovernableAdapter.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.27;
 import {IGovernable} from "../interfaces/IGovernable.sol";
 import {ISFC} from "../interfaces/ISFC.sol";
 
-// @dev SFCToGovernable is an adapter allowing to use the network SFC contract as IGovernable.sol (governance votes weights provider).
+// @dev SFCToGovernable is an adapter allowing to use the network SFC contract as IGovernable (governance votes weights provider).
 contract SFCGovernableAdapter is IGovernable {
     ISFC internal immutable sfc;
 

--- a/contracts/adapters/SFCGovernableAdapter.sol
+++ b/contracts/adapters/SFCGovernableAdapter.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import {Governable} from "../model/Governable.sol";
+import {IGovernable} from "../interfaces/IGovernable.sol";
 import {ISFC} from "../interfaces/ISFC.sol";
 
-// @dev SFCToGovernable is an adapter allowing to use the network SFC contract as Governable (governance votes weights provider).
-contract SFCGovernableAdapter is Governable {
+// @dev SFCToGovernable is an adapter allowing to use the network SFC contract as IGovernable.sol (governance votes weights provider).
+contract SFCGovernableAdapter is IGovernable {
     ISFC internal immutable sfc;
 
     constructor(address _sfcAddress) {

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import {Governable} from "../model/Governable.sol";
+import {IGovernable} from "../interfaces/IGovernable.sol";
 import {IProposal} from "../interfaces/IProposal.sol";
 import {IProposalVerifier} from "../verifiers/IProposalVerifier.sol";
 import {Proposal} from "./Proposal.sol";
@@ -46,7 +46,7 @@ contract Governance is Initializable, ReentrancyGuardTransient, GovernanceSettin
         uint256 proposalID;
     }
 
-    Governable public governableContract; // SFC to Governable adapter refer to SFCToGovernable.sol
+    IGovernable public governableContract; // SFC to Governable adapter refer to SFCToGovernable.sol
     IProposalVerifier public proposalVerifier;
     uint256 public lastProposalID;
 
@@ -120,7 +120,7 @@ contract Governance is Initializable, ReentrancyGuardTransient, GovernanceSettin
     /// @param _proposalVerifier The address of the proposal verifier.
     /// @param _votebook The address of the votebook contract.
     function initialize(address _governableContract, address _proposalVerifier, address _votebook) public initializer {
-        governableContract = Governable(_governableContract);
+        governableContract = IGovernable(_governableContract);
         proposalVerifier = IProposalVerifier(_proposalVerifier);
         votebook = VotesBookKeeper(_votebook);
     }

--- a/contracts/governance/Governance.sol
+++ b/contracts/governance/Governance.sol
@@ -46,7 +46,7 @@ contract Governance is Initializable, ReentrancyGuardTransient, GovernanceSettin
         uint256 proposalID;
     }
 
-    IGovernable public governableContract; // SFC to Governable adapter refer to SFCToGovernable.sol
+    IGovernable public governableContract; // SFC to Governable adapter refer to SFCToGovernable
     IProposalVerifier public proposalVerifier;
     uint256 public lastProposalID;
 

--- a/contracts/governance/GovernanceSettings.sol
+++ b/contracts/governance/GovernanceSettings.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.27;
 
 import {Decimal} from "../common/Decimal.sol";
-import {Governable} from "../model/Governable.sol";
+import {IGovernable} from "../interfaces/IGovernable.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice GovernanceSettings is a contract for managing governance settings

--- a/contracts/interfaces/IGovernable.sol
+++ b/contracts/interfaces/IGovernable.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.27;
 
 
-/// @notice Governable defines the main interface for all governable items
-interface Governable {
+/// @notice IGovernable.sol defines the main interface for all governable items
+interface IGovernable {
     /// @notice Retrieves the total active stake across all validators.
     /// @return The sum of all active delegated stakes.
     function getTotalWeight() external view returns (uint256);

--- a/contracts/interfaces/IGovernable.sol
+++ b/contracts/interfaces/IGovernable.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.27;
 
 
-/// @notice IGovernable.sol defines the main interface for all governable items
+/// @notice IGovernable defines the main interface for all governable items
 interface IGovernable {
     /// @notice Retrieves the total active stake across all validators.
     /// @return The sum of all active delegated stakes.


### PR DESCRIPTION
This PR move `Govarnable` from `./model/Governable.sol` to `./interface/IGovernable.sol` and renames interface `Governable` to `IGovernable.sol`