### PR TITLE
Copy votesbook functionality into governance.

### DIFF
--- a/test/ProposalFactory.ts
+++ b/test/ProposalFactory.ts
@@ -10,7 +10,7 @@ const proposalFactoryFixture = async function () {
     await verifier.initialize(acc1);
     const gov = await ethers.deployContract("Governance");
     // Governable and VoteBook are not necessary for this test
-    await gov.initialize(ethers.ZeroAddress, await verifier.getAddress(), ethers.ZeroAddress)
+    await gov.initialize(ethers.ZeroAddress, await verifier.getAddress(), 1000, ethers.ZeroAddress)
     return {gov, verifier, acc1, acc2}
 }
 


### PR DESCRIPTION
This PR copies `votesbook` functionality into the governance contract. It also copies the votesbook checks to be applied from the governance perspective in `Governance voting tests`.
This PR does not remove the `votesbook` contract as that requires a deeper refactoring in `Governance.sol` contract as well as `Governance.ts` tests.